### PR TITLE
Add Dependabot config for mix ecosystem and daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Updated Dependabot configuration to use 'mix' as the package ecosystem and changed the update schedule from weekly to daily.